### PR TITLE
Select multiple matches

### DIFF
--- a/lib/SuperSelectField.js
+++ b/lib/SuperSelectField.js
@@ -316,9 +316,11 @@ var SelectField = function (_Component) {
             return !areEqual(obj.value, selectedItem.value);
           }) : selectedItems.concat(selectedItem);
           _this.setState({ selectedItems: updatedValues });
-          _this.clearTextField(function () {
-            return _this.focusTextField();
-          });
+          if (_this.props.clearAutocompleteUponSelection) {
+            _this.clearTextField(function () {
+              return _this.focusTextField();
+            });
+          }
         } else {
           var updatedValue = areEqual(selectedItems, selectedItem) ? null : selectedItem;
           _this.setState({ selectedItems: updatedValue }, function () {
@@ -857,7 +859,8 @@ SelectField.propTypes = {
   menuCloseButton: _react.PropTypes.node,
   multiple: _react.PropTypes.bool,
   disabled: _react.PropTypes.bool,
-  onChange: _react.PropTypes.func
+  onChange: _react.PropTypes.func,
+  clearAutocompleteUponSelection: _react.PropTypes.bool
 };
 
 SelectField.defaultProps = {
@@ -882,6 +885,7 @@ SelectField.defaultProps = {
   },
   value: null,
   onChange: function onChange() {},
+  clearAutocompleteUponSelection: false,
   children: []
 };
 

--- a/lib/SuperSelectField.js
+++ b/lib/SuperSelectField.js
@@ -885,7 +885,7 @@ SelectField.defaultProps = {
   },
   value: null,
   onChange: function onChange() {},
-  clearAutocompleteUponSelection: false,
+  clearAutocompleteUponSelection: true,
   children: []
 };
 

--- a/src/SuperSelectField.js
+++ b/src/SuperSelectField.js
@@ -702,7 +702,7 @@ SelectField.defaultProps = {
   },
   value: null,
   onChange: () => {},
-  clearAutocompleteUponSelection: false,
+  clearAutocompleteUponSelection: true,
   children: []
 }
 

--- a/src/SuperSelectField.js
+++ b/src/SuperSelectField.js
@@ -321,7 +321,9 @@ class SelectField extends Component {
         ? selectedItems.filter(obj => !areEqual(obj.value, selectedItem.value))
         : selectedItems.concat(selectedItem)
       this.setState({ selectedItems: updatedValues })
-      this.clearTextField(() => this.focusTextField())
+      if (this.props.clearAutocompleteUponSelection) {
+          this.clearTextField(() => this.focusTextField())
+      }
     } else {
       const updatedValue = areEqual(selectedItems, selectedItem) ? null : selectedItem
       this.setState({ selectedItems: updatedValue }, () => this.closeMenu())
@@ -674,7 +676,8 @@ SelectField.propTypes = {
   menuCloseButton: PropTypes.node,
   multiple: PropTypes.bool,
   disabled: PropTypes.bool,
-  onChange: PropTypes.func
+  onChange: PropTypes.func,
+  clearAutocompleteUponSelection: PropTypes.bool
 }
 
 SelectField.defaultProps = {
@@ -699,6 +702,7 @@ SelectField.defaultProps = {
   },
   value: null,
   onChange: () => {},
+  clearAutocompleteUponSelection: false,
   children: []
 }
 


### PR DESCRIPTION
This PR adds a new property that enables you to select multiple matching options before the autocomplete filter is cleared.